### PR TITLE
Suggestion: make slides viewable online

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>LINGI2401 - 1. Introduction and history</title>
+    <meta charset="utf-8">
+    <style>
+      @import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz);
+      @import url(https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
+      @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
+
+      body { font-family: 'Droid Serif'; }
+      h1, h2, h3 {
+        font-family: 'Yanone Kaffeesatz';
+        font-weight: normal;
+      }
+      .remark-code, .remark-inline-code { font-family: 'Ubuntu Mono'; }
+    </style>
+  </head>
+  <body>
+    <textarea id="source">
+
+class: left, left
+
+# LINGI 2401 : Open Source strategy for software development
+Table of contents
+
+1. [Introduction and history](1. introduction and history)
+2. [Licenses](2. licenses)
+3. [Business models](3. business models)
+4. [Community](4. community)
+5. [Choosing opensource](5. choosing opensource)
+6. [Privacy and Security](6. privacy and security)
+7. [Decentralisation and standardisation](7. decentralisation and standardisation)
+    * [Wikipedia](7b. Wikipedia)
+8. [Open source in entreprises](8. open source in entreprises)
+9. [Changing the world](9. changing the world)
+10. [Blockchain](10. blockchain)
+
+
+
+
+
+
+    </textarea>
+    <script src="https://remarkjs.com/downloads/remark-latest.min.js">
+    </script>
+    <script>
+      var slideshow = remark.create();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Hi, 

I have small suggestion for the course repo. For the moment the slides cannot be seen online when on GitHub (you see the raw file, as if viewing the source code, but it is not rendered in the browser). For instance : 
* https://github.com/ploum/lingi2401/blob/master/1.%20introduction%20and%20history.html
* if you click on `raw` in the above link : https://raw.githubusercontent.com/ploum/lingi2401/master/1.%20introduction%20and%20history.html

On way is to copy the repo and view them locally in your browser.

Another way to bypass that, is to use the built-in GitHub Pages. 

Could you activate the GitHub Pages for the repo? 

To do that : 
* go to the [`Repo Settings`](https://github.com/ploum/lingi2401/settings);
* scroll down to `GitHub Pages`;
* choose `master branch` and save. 

Basically, GitHub will search for an `index.html` file on the repo to build the website (see [GitHub Help](https://help.github.com/categories/github-pages-basics/) for more details). Once the GitHub Page is active, the course link should be : http://ploum.github.io/lingi2401

As a proof of concept, I activated the Github Pages on my fork. To see the results:

http://pgonzalezalv.github.io/lingi2401

To make it work, I added a basic `index.html` file. See commit for more details.