### PR TITLE
Adding project suggestion

### DIFF
--- a/projects.csv
+++ b/projects.csv
@@ -3,3 +3,4 @@ Alexandre Dewit, Vue js, https://github.com/vuejs/vue, to be determined
 Maxime Franco, swagger-check, https://github.com/adimian/swagger-check, to be determined
 Ngongang Gilles, teammates, https://github.com/TEAMMATES/teammates, to be determined
 Laritza Cabrera Alba, Exercism, https://github.com/exercism/java, to be determined
+Nicolas Rybowski, apk-tools, https://git.alpinelinux.org/apk-tools/, Adding this feature : https://gitlab.alpinelinux.org/alpine/apk-tools/issues/8792


### PR DESCRIPTION
APK is the package manager from the Alpine Linux distribution. I'm using this distribution for years for lightweight containers/VM's and as bare-metal OS for Rapberry Pi's so I'm very interested to collaborate on this project.

I already found the contribution that I wish to implement as precised in the `projects.csv` file.

The main repository for this project is the one given in `projects.csv` but there is a [mirror on github ](https://github.com/alpinelinux/apk-tools) if the use of github is mandatory for this course.